### PR TITLE
Update golangci-lint to v1.64.6

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -3,7 +3,7 @@ version: 3
 vars:
   PROJECT_BIN_DIR: "$(pwd)/bin"
 
-  GOLANGCI_LINT_VERSION: "v1.62.0"
+  GOLANGCI_LINT_VERSION: "v1.64.6"
   GOLANGCI_LINT_BIN: "{{ .PROJECT_BIN_DIR }}/golangci-lint"
 
 tasks:


### PR DESCRIPTION
## Summary
- Update golangci-lint from v1.62.0 to v1.64.6 to benefit from latest linting improvements and bug fixes

## Test plan
- Verified that linting works correctly with `task lint`
- Ran all tests with `task test` to ensure no regressions

🤖 Generated with [Claude Code](https://claude.ai/code)