### PR TITLE
Add explicit permissions to GitHub workflows

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,6 +6,10 @@ on:
     branches:
       - main
 
+# Default permissions for all jobs
+permissions:
+  contents: read
+
 jobs:
   setup:
     runs-on: ubuntu-latest
@@ -34,6 +38,9 @@ jobs:
   tests:
     needs:   setup
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      statuses: write  # Required for codecov
     steps:
       - name: checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
## Summary
- Added explicit permissions to GitHub workflows for improved security
- Default permissions are set to read-only for contents
- Added statuses:write permission to tests job for codecov reporting

## Test plan
- Verified workflow steps run without errors
- Confirmed all tests pass with `task test`
- Confirmed linting passes with `task lint`

🤖 Generated with [Claude Code](https://claude.ai/code)