### PR TITLE
Separate field router and matcher

### DIFF
--- a/match/errors.go
+++ b/match/errors.go
@@ -1,0 +1,8 @@
+package match
+
+import "errors"
+
+var (
+	errFieldNotFound = errors.New("field not found")
+	errNotAStruct    = errors.New("not a struct")
+)

--- a/match/router.go
+++ b/match/router.go
@@ -1,0 +1,114 @@
+package match
+
+import (
+	"reflect"
+	"strings"
+)
+
+// ReflectRouter implements Router for struct targets.
+// It supports struct tags using the `dumbql` tag name and nested field access using dot notation.
+type ReflectRouter struct{}
+
+// Route resolves a field path in the target struct and returns the value.
+// It supports nested field access using dot notation (e.g., "address.city").
+func (r *ReflectRouter) Route(target any, field string) (any, error) {
+	// Handle dot notation for nested fields
+	parts := strings.Split(field, ".")
+
+	// Process single field name - common case
+	if len(parts) == 1 {
+		return r.resolveDirectField(target, field)
+	}
+
+	// Handle nested fields traversal
+	return r.resolveNestedField(target, parts)
+}
+
+// resolveDirectField handles resolving a direct field (no dots in the name)
+func (r *ReflectRouter) resolveDirectField(target any, field string) (any, error) {
+	v := reflect.ValueOf(target)
+	if v.Kind() == reflect.Ptr {
+		if v.IsNil() {
+			return nil, errNotAStruct // Nil pointer, can't resolve field
+		}
+		v = v.Elem()
+	}
+
+	if v.Kind() != reflect.Struct {
+		return nil, errNotAStruct // Not a struct, can't resolve field
+	}
+
+	t := v.Type()
+	for i := range t.NumField() {
+		f := t.Field(i)
+
+		tag := f.Tag.Get("dumbql")
+		if tag == "-" {
+			// Field marked with dumbql:"-" is skipped
+			return nil, errFieldNotFound
+		}
+
+		fname := f.Name
+		if tag != "" {
+			fname = tag
+		}
+
+		if fname == field {
+			return v.Field(i).Interface(), nil
+		}
+	}
+
+	// Field not found
+	return nil, errFieldNotFound
+}
+
+// resolveNestedField handles traversing nested fields using dot notation
+func (r *ReflectRouter) resolveNestedField(target any, path []string) (any, error) {
+	current := target
+
+	// Navigate through all segments except the last one
+	for i := range len(path) - 1 {
+		v := reflect.ValueOf(current)
+		if v.Kind() == reflect.Ptr {
+			if v.IsNil() {
+				return nil, errNotAStruct // Nil pointer, can't traverse further
+			}
+			v = v.Elem()
+		}
+
+		if v.Kind() != reflect.Struct {
+			return nil, errNotAStruct // Not a struct, cannot traverse
+		}
+
+		// Find field by name or tag
+		t := v.Type()
+		found := false
+
+		for j := range t.NumField() {
+			f := t.Field(j)
+
+			tag := f.Tag.Get("dumbql")
+			if tag == "-" {
+				return nil, errFieldNotFound // Field marked with dumbql:"-" is skipped
+			}
+
+			fname := f.Name
+			if tag != "" {
+				fname = tag
+			}
+
+			if fname == path[i] {
+				current = v.Field(j).Interface()
+				found = true
+				break
+			}
+		}
+
+		if !found {
+			return nil, errFieldNotFound // Field not found
+		}
+	}
+
+	// Resolve the final segment
+	return r.resolveDirectField(current, path[len(path)-1])
+}

--- a/match/struct.go
+++ b/match/struct.go
@@ -1,15 +1,36 @@
 package match
 
 import (
-	"reflect"
-	"strings"
+	"errors"
 
 	"go.tomakado.io/dumbql/query"
 )
 
+// Router is responsible for resolving a field path to a value in the target object.
+// It abstracts the field resolution logic from the matcher implementation.
+type Router interface {
+	// Route resolves a field path in the target object and returns the value.
+	// The boolean return value indicates whether the field was successfully resolved.
+	Route(target any, field string) (any, error)
+}
+
 // StructMatcher is a basic implementation of the Matcher interface for evaluating query expressions against structs.
 // It supports struct tags using the `dumbql` tag name, which allows you to specify a custom field name.
-type StructMatcher struct{}
+type StructMatcher struct {
+	router Router
+}
+
+func NewStructMatcher(router Router) *StructMatcher {
+	return &StructMatcher{
+		router: router,
+	}
+}
+
+func (m *StructMatcher) lazyInit() {
+	if m.router == nil {
+		m.router = &ReflectRouter{}
+	}
+}
 
 func (m *StructMatcher) MatchAnd(target any, left, right query.Expr) bool {
 	return left.Match(target, m) && right.Match(target, m)
@@ -27,102 +48,13 @@ func (m *StructMatcher) MatchNot(target any, expr query.Expr) bool {
 // It supports struct tags using the `dumbql` tag name and nested field access using dot notation.
 // For example: "address.city" to access the city field in the address struct.
 func (m *StructMatcher) MatchField(target any, field string, value query.Valuer, op query.FieldOperator) bool {
-	// Handle dot notation for nested fields
-	parts := strings.Split(field, ".")
+	m.lazyInit()
 
-	// Process single field name - common case
-	if len(parts) == 1 {
-		return m.matchDirectField(target, field, value, op)
+	fieldValue, err := m.router.Route(target, field)
+	if err != nil {
+		return errors.Is(err, errFieldNotFound)
 	}
-
-	// Handle nested fields traversal
-	return m.matchNestedField(target, parts, value, op)
-}
-
-// matchDirectField handles matching a direct field (no dots in the name)
-func (m *StructMatcher) matchDirectField(target any, field string, value query.Valuer, op query.FieldOperator) bool {
-	v := reflect.ValueOf(target)
-	if v.Kind() == reflect.Ptr {
-		v = v.Elem()
-	}
-
-	if v.Kind() != reflect.Struct {
-		return false
-	}
-
-	t := v.Type()
-	for i := 0; i < t.NumField(); i++ {
-		f := t.Field(i)
-
-		tag := f.Tag.Get("dumbql")
-		if tag == "-" {
-			// Field marked with dumbql:"-" always match (in other words does not affect the result)
-			return true
-		}
-
-		fname := f.Name
-		if tag != "" {
-			fname = tag
-		}
-
-		if fname == field {
-			return m.MatchValue(v.Field(i).Interface(), value, op)
-		}
-	}
-
-	// If field not found, return true (same behavior as original)
-	return true
-}
-
-// matchNestedField handles traversing nested fields using dot notation
-func (m *StructMatcher) matchNestedField(target any, path []string, value query.Valuer, op query.FieldOperator) bool {
-	current := target
-
-	// Navigate through all segments except the last one
-	for i := 0; i < len(path)-1; i++ {
-		v := reflect.ValueOf(current)
-		if v.Kind() == reflect.Ptr {
-			if v.IsNil() {
-				return true // Nil pointer, can't traverse further
-			}
-			v = v.Elem()
-		}
-
-		if v.Kind() != reflect.Struct {
-			return false // Not a struct, cannot traverse
-		}
-
-		// Find field by name or tag
-		t := v.Type()
-		found := false
-
-		for j := 0; j < t.NumField(); j++ {
-			f := t.Field(j)
-
-			tag := f.Tag.Get("dumbql")
-			if tag == "-" {
-				return true // Field marked with dumbql:"-" always matches
-			}
-
-			fname := f.Name
-			if tag != "" {
-				fname = tag
-			}
-
-			if fname == path[i] {
-				current = v.Field(j).Interface()
-				found = true
-				break
-			}
-		}
-
-		if !found {
-			return true // Field not found, behave same as current implementation
-		}
-	}
-
-	// Match the final segment
-	return m.matchDirectField(current, path[len(path)-1], value, op)
+	return m.MatchValue(fieldValue, value, op)
 }
 
 func (m *StructMatcher) MatchValue(target any, value query.Valuer, op query.FieldOperator) bool {


### PR DESCRIPTION
## Summary
- Separated field routing logic from matching logic for better separation of concerns
- Introduced Router interface to abstract field resolution from matching
- Implemented ReflectRouter to handle struct field resolution
- Refactored StructMatcher to use Router for field resolution

## Test plan
- All existing tests continue to pass without modification
- Additional tests for the new components may be added in follow-up PRs

🤖 Generated with [Claude Code](https://claude.ai/code)